### PR TITLE
fix: lock geckodriver version to ensure correct screenshot size

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "chromedriver": "^2.35.0",
     "commander": "^2.13.0",
-    "geckodriver": "^1.10.0",
+    "geckodriver": "1.12.2",
     "glob": "^7.1.2",
     "http-server": "^0.11.1",
     "imagemin-optipng": "^5.2.1",


### PR DESCRIPTION
Starting with node-geckodriver v1.13.0, element.takeScreenshot saves the entire viewport and not the element. I've locked the version to 1.12.2 which works correctly.

Related to vladikoff/node-geckodriver#55