### PR TITLE
feat: add support for JSON  pastshotsrc file

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function readConfig() {
   const configName = './.pastshotsrc';
 
   if (!fs.existsSync(configName)) {
-    return JSON.parse('{}');
+    return {};
   }
 
   try {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,22 @@
 const program = require('commander');
 const fs = require('fs');
 const package = require('./package.json');
+const configName = './.pastshotsrc';
+
+function readConfig() {
+  if (fs.existsSync(configName)) {
+    try {
+      return JSON.parse(fs.readFileSync(configName, 'utf8'));
+    } catch(e) {
+      console.error('Can not parse .pasthostsrc');
+      console.error(e);
+      process.exit(1);
+    }
+  } else {
+    return JSON.parse('{}');
+  }
+};
+const pastshotsrc = readConfig();
 
 // "pastshots --output tests/output --host tests/visual/*.html --port 8081",
 
@@ -24,7 +40,7 @@ program
   .option('--create-diff <boolean>', 'Create diff image', false)
   .parse(process.argv);
 
-const { browser, serve, port, output, viewportSize, selector, tolerance, createDiff } = program;
+const { browser, serve, port, output, viewportSize, selector, tolerance, createDiff } = { ...program, ...pastshotsrc };
 const glob = require('glob');
 const pages = glob.sync(serve);
 

--- a/index.js
+++ b/index.js
@@ -3,21 +3,22 @@
 const program = require('commander');
 const fs = require('fs');
 const package = require('./package.json');
-const configName = './.pastshotsrc';
 
 function readConfig() {
-  if (fs.existsSync(configName)) {
-    try {
-      return JSON.parse(fs.readFileSync(configName, 'utf8'));
-    } catch(e) {
-      console.error('Can not parse .pasthostsrc');
-      console.error(e);
-      process.exit(1);
-    }
-  } else {
+  const configName = './.pastshotsrc';
+
+  if (!fs.existsSync(configName)) {
     return JSON.parse('{}');
   }
-};
+
+  try {
+    return JSON.parse(fs.readFileSync(configName, { encoding: 'utf-8' }));
+  } catch(e) {
+    console.error('Can not parse .pasthostsrc');
+    console.error(e);
+    process.exit(1);
+  }
+}
 const pastshotsrc = readConfig();
 
 // "pastshots --output tests/output --host tests/visual/*.html --port 8081",


### PR DESCRIPTION
Add support for JSON based .pastshotsrc config file.

Given a pastshotsrc file

```json
{
    "serve": "tests/visual/*.html",
    "port": 8081,
    "selector": "#test-area",
    "viewportSize": {
        "width": 1200,
        "height": 768
    },
    "tolerance": 1
}
```

the following exerpt
```bash
pastshots --output tests/visual/output/$theme --serve 'tests/visual/*.html' --port 8081 --selector "#test-area" --viewport-size 1200,768 --tolerance 1
```
becomes
```bash
pastshots --output tests/visual/output/$theme
```