### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "chromedriver": "^2.35.0",
     "commander": "^2.13.0",
     "geckodriver": "1.12.2",
-    "glob": "^7.1.2",
+    "glob": "^7.1.6",
     "http-server": "^0.11.1",
-    "imagemin-optipng": "^5.2.1",
+    "imagemin-optipng": "^8.0.0",
     "looks-same": "^3.3.0",
     "mkdirp": "^0.5.1",
     "selenium-webdriver": "^3.6.0"


### PR DESCRIPTION
* update imagemin-optipng to 8.0.0
* update glob to 7.1.2

That's needed to [CVE-2020-8244](target https://github.com/advisories/GHSA-pp7h-53gx-mx7r) --  Remote Memory Exposure in bl.

I guess the commit could be "fix"?