### PR TITLE
chore: upgrade node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
   email: false
 
 node_js:
-  - '8'
+  - '12'
 
 after_success:
   - npx semantic-release


### PR DESCRIPTION
Attempt to fix `npm WARN npm npm does not support Node.js v8.17.0` from https://travis-ci.org/github/gyoshev/pastshots/builds/771797778